### PR TITLE
Update apicast definition to include write permissions for /insights

### DIFF
--- a/apicast-slave/Dockerfile
+++ b/apicast-slave/Dockerfile
@@ -13,7 +13,10 @@ RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
     yum clean all && \
     mkdir -p /var/lib/jenkins && \
     chown -R 1001:0 /var/lib/jenkins && \
-    chmod -R g+w /var/lib/jenkins
+    chmod -R g+w /var/lib/jenkins && \
+    mkdir -p /insights && \
+    chmod 777 /insights && \
+    chown 1001:0 /insights
 
 # Copy the entrypoint
 COPY configuration/* /var/lib/jenkins/


### PR DESCRIPTION
Builds for 3scale have been failing due to insufficient permissions for creating the /insights folder on the build runner. This PR updates the runner image such that the /insights folder will already exist and be world-writeable.